### PR TITLE
publish dmarc records for our zones

### DIFF
--- a/zones/linuxfests/linuxfests.org.zone
+++ b/zones/linuxfests/linuxfests.org.zone
@@ -9,6 +9,7 @@ $ORIGIN linuxfests.org.
 @	172800	IN	NS	ns-587.awsdns-09.net.
 @	3600	IN	TXT	"v=spf1 include:actusa.net mx a:outsidemailers.linuxfests.org - -all"
 google._domainkey   IN      TXT     "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxh05VrHxdv6eiJpKP6CbjkIMCji3qPkkuFmlAm3MBxpAoOgrXcou/JfZEOUkTk00V9jZPgH7jhNjsY0d8GeVu2fDzgcxcHPS3idZ89K5SElE0L8fXwf/p7ARFBukrh8LxADy+pHIaRpAKF/cw8CUmYpgRBYCCIyVzt1H623Dokbu8xQx+i0DK5sDgu72yz3LvBQQTHmOdct1oEOMHtQc4IOTDvy6qElQrmhOLejmN40IV94tKtg56Z4dfHXtkHBAbwUap1vtE20tUYkxi1kJ0Uf4uQm3hwugDarP3osO+e/aCnfoErT9/0gKbL7F8D9rTFLm17BAWfaIDgHTdt/DuQIDAQAB"
+_dmarc          IN      TXT     "v=DMARC1; p=none; rua=mailto:pi3ti8fx@ag.dmarcian.com;"
 db	3600	IN	A	208.83.101.226
 db	3600	IN	AAAA	2607:ff38:2:6::e2
 db	3600	IN	TXT	"v=spf1 a -all"

--- a/zones/scale/socallinuxexpo.org.zone
+++ b/zones/scale/socallinuxexpo.org.zone
@@ -9,6 +9,7 @@ $ORIGIN socallinuxexpo.org.
 @	172800	IN	NS	ns-784.awsdns-34.net.
 @	3600	IN	TXT	"v=spf1 include:linuxfests.org ip4:216.113.188.96 mx a:mail.socallinuxexpo.org ~all"
 google._domainkey   IN      TXT     "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqyFMZwDrNjPuXeTDUVR5mnsrh/cK6RyjcYp0lC4UOTpEdcqu+Bt0pNw1Dq2LYEAbzdAk0ffnVR7qgwE4AlyqxAIfc45DYriXQ6BB2zTKUcqOTT5WOTQRv8teF4CQyzmd6OF3tXaMK21pVnVG7eVXu44FIsE4TQYTpH/axlj1p9119RmNSbHfFJEfcbRs6qRHLGnpfNxtZLoVjf5KikfHKfQFYjtZHQsC43sATmcVEsesj/Xih3e/wQ2mXx1/u7wDQawk1Rs/7ORV8VfEYVEAQWcoJ4Ec0XS5Q0kY1UW2uqytlqAYbVtuYSOoKCQJ1ykeH5YKH/uGXjmOjoVOkgdSVwIDAQAB"
+_dmarc          IN      TXT     "v=DMARC1; p=none; rua=mailto:pi3ti8fx@ag.dmarcian.com;"
 _sip._udp	3600	IN	SRV	0 0 5060 sip.socallinuxexpo.com.
 asterisk	3600	IN	A	208.83.101.234
 audio	3600	IN	A	209.208.107.64


### PR DESCRIPTION
This commit adds DMARC records to our zones. For now we are setting a policy of NONE. This means that recipients of mail will report back to us if they receive mail that:

1) Doesn't match our SPF records
2) Doesn't match our DKIM signatures

This information will in turn allow us to identify sources of mail from our domains so that we can either migrate them behind the correct systems, or add the missing systems to our published policies.

I am explicitly choosing not to set our policy to reject or quarantine as we do not yet have a control on all our mail systems. Additionally there are known issues around DKIM with strict policies and mailman in our environments right now that need to be addressed first.
