### PR TITLE
verify linuxfests.* and socallinuxexpo.* with Google Apps

### DIFF
--- a/zones/linuxfests/linuxfests.org.zone
+++ b/zones/linuxfests/linuxfests.org.zone
@@ -35,3 +35,5 @@ outsidemailers	3600	IN	AAAA	2607:ff38:3::48
 outsidemailers	3600	IN	AAAA	2607:ff38:2:6::e8
 www	3600	IN	A	208.83.101.227
 www	3600	IN	AAAA	2607:ff38:2:6::e3
+tskzc2mudznc    IN  CNAME   gv-2mbpmgf6ikwlin.dv.googlehosted.com.
+6mbbjr3glwz6    IN  CNAME   gv-znt3xbswxepvdi.dv.googlehosted.com.

--- a/zones/scale/socallinuxexpo.org.zone
+++ b/zones/scale/socallinuxexpo.org.zone
@@ -64,3 +64,5 @@ wiki	3600	IN	AAAA	2607:ff38:2:6::e7
 www-reg	3600	IN	A	208.83.101.234
 www	3600	IN	A	208.83.101.230
 www	3600	IN	AAAA	2607:ff38:2:6::e6
+jg5uqz5onam7    IN      CNAME   gv-isydihgzzmtlnj.dv.googlehosted.com.
+gvekrzn2wjbd    IN      CNAME   gv-atkfixrdalxfdz.dv.googlehosted.com.


### PR DESCRIPTION
Verifying our .com/net domains with google so we can setup email aliases for everyone.
