### PR TITLE
first pass at removing stale DNS records

### DIFF
--- a/zones/linuxfests/linuxfests.org.zone
+++ b/zones/linuxfests/linuxfests.org.zone
@@ -17,11 +17,6 @@ _dmarc	3600	IN	TXT	"v=DMARC1; p=none; rua=mailto:pi3ti8fx@ag.dmarcian.com;"
 db	3600	IN	A	208.83.101.226
 db	3600	IN	AAAA	2607:ff38:2:6::e2
 db	3600	IN	TXT	"v=spf1 a -all"
-devopsreg	3600	IN	A	54.235.255.32
-devopsreg	3600	IN	TXT	"v=spf1 a -all"
-documents	3600	IN	A	208.83.101.235
-documents	3600	IN	AAAA	2607:ff38:2:6::eb
-documents	3600	IN	TXT	"v=spf1 a -all"
 google._domainkey	3600	IN	TXT	"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxh05VrHxdv6eiJpKP6CbjkIMCji3qPkkuFmlAm3MBxpAoOgrXcou/JfZEOUkTk00V9jZPgH7jhNjsY0d8GeVu2fDzgcxcHPS3idZ89K5SElE0L8fXwf/p7ARFBukrh8LxADy+pHIaRpAKF/cw8CUmYpgRBYCCIyVzt1H623Dokbu8xQx+i0DK5sDgu72yz3Lv" "BQQTHmOdct1oEOMHtQc4IOTDvy6qElQrmhOLejmN40IV94tKtg56Z4dfHXtkHBAbwUap1vtE20tUYkxi1kJ0Uf4uQm3hwugDarP3osO+e/aCnfoErT9/0gKbL7F8D9rTFLm17BAWfaIDgHTdt/DuQIDAQAB"
 lists	3600	IN	A	208.83.101.229
 lists	3600	IN	AAAA	2607:ff38:2:6::e5

--- a/zones/scale/socallinuxexpo.org.zone
+++ b/zones/scale/socallinuxexpo.org.zone
@@ -15,22 +15,13 @@ $ORIGIN socallinuxexpo.org.
 _dmarc	3600	IN	TXT	"v=DMARC1; p=none; rua=mailto:pi3ti8fx@ag.dmarcian.com;"
 _sip._udp	3600	IN	SRV	0 0 5060 sip.socallinuxexpo.com.
 asterisk	3600	IN	A	208.83.101.234
-audio	3600	IN	A	209.208.107.64
-blog	3600	IN	A	208.83.101.234
-blog	3600	IN	AAAA	2607:ff38:1:81::3
-cfp	3600	IN	A	208.83.101.230
-cfp	3600	IN	AAAA	2607:ff38:2:6::e6
 devserv	3600	IN	A	208.83.101.234
 devserv	3600	IN	AAAA	2607:ff38:1:81::3
 dynamic-ipv6-expo	3600	IN	AAAA	2607:ff38:1:8100::1
 expo	3600	IN	A	8.193.40.80
 expo	3600	IN	AAAA	2607:ff38:3:8100::1
-feeds	3600	IN	CNAME	null.feedproxy.ghs.google.com.
 google._domainkey	3600	IN	TXT	"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqyFMZwDrNjPuXeTDUVR5mnsrh/cK6RyjcYp0lC4UOTpEdcqu+Bt0pNw1Dq2LYEAbzdAk0ffnVR7qgwE4AlyqxAIfc45DYriXQ6BB2zTKUcqOTT5WOTQRv8teF4CQyzmd6OF3tXaMK21pVnVG7eVXu44FIsE4TQYTpH/axlj1p9119RmNSbHfFJEfcbRs6qRHL" "GnpfNxtZLoVjf5KikfHKfQFYjtZHQsC43sATmcVEsesj/Xih3e/wQ2mXx1/u7wDQawk1Rs/7ORV8VfEYVEAQWcoJ4Ec0XS5Q0kY1UW2uqytlqAYbVtuYSOoKCQJ1ykeH5YKH/uGXjmOjoVOkgdSVwIDAQAB"
 gvekrzn2wjbd	3600	IN	CNAME	gv-atkfixrdalxfdz.dv.googlehosted.com.
-helpdesk	3600	IN	A	74.121.4.72
-helpdesk	3600	IN	AAAA	2607:ff38:3::48
-helpdesk	3600	IN	MX	10 mail.linuxfests.org.
 jg5uqz5onam7	3600	IN	CNAME	gv-isydihgzzmtlnj.dv.googlehosted.com.
 lists	3600	IN	A	208.83.101.229
 lists	3600	IN	AAAA	2607:ff38:2:6::e5
@@ -41,9 +32,6 @@ maggie	3600	IN	MX	10 mail.socallinuxexpo.org.
 mail	3600	IN	A	208.83.101.226
 mail	3600	IN	AAAA	2607:ff38:2:6::e2
 mail	3600	IN	TXT	"v=spf1 a -all"
-otrs	3600	IN	A	208.83.101.206
-otrs	3600	IN	AAAA	2607:ff38:1:86::8
-photos	3600	IN	CNAME	scale.trovebox.com.
 reg	3600	IN	A	208.83.101.232
 reg	3600	IN	AAAA	2607:ff38:2:6::e8
 rondevel	3600	IN	A	208.83.101.234
@@ -62,11 +50,8 @@ signs	3600	IN	A	74.121.4.41
 sip	3600	IN	A	208.83.101.234
 tlfweb	3600	IN	A	208.83.101.228
 tlfweb	3600	IN	AAAA	2607:ff38:2:6::e4
-utility	3600	IN	A	208.83.101.233
-utility	3600	IN	AAAA	2607:ff38:2:6::e9
 voip	3600	IN	A	208.83.101.234
 wiki	3600	IN	A	208.83.101.231
 wiki	3600	IN	AAAA	2607:ff38:2:6::e7
-www-reg	3600	IN	A	208.83.101.234
 www	3600	IN	A	208.83.101.230
 www	3600	IN	AAAA	2607:ff38:2:6::e6


### PR DESCRIPTION
Theres are records for legacy systems that haven't been online in 1 year+. 

socallinuxexpo.\* likely has more we can clean up after we complete our move out of ActUSA, but this is a good start.

-Ilan
